### PR TITLE
add swarmsim as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+swarmsim
 tqdm
 pandas
 openpyxl


### PR DESCRIPTION
# Change

Add `swarmsim` to `requirements.txt` so that when users run `pip install -r requirements.txt`, `swarmsim` will get installed to the user's environment.

# Rationale
This repository is mostly centered around using SNNs + RobotSwarmSimulator (`swarmsim`). 

In the past, other simulators were involved, but this is not the case right now. The scripts that are actively being used are focused on `swarmsim`.

It might make sense to add this as a requirement in `requirements.txt`.

The current steps for being able to run `experiment_tenn2.py` are:

1. create a project folder 
2. create and activate a Python virtual environment
3. `pip install swarmsim`
    * Dev installs need to `git clone` the rss repo, then `pip install -e RobotSwarmSimulator[dev,docs]`
4. `git clone` this repo
5. `cd` to this repo, then `pip install -r requirements.txt`

This pull request would remove the need to perform step 3 for non-dev (non-editable) installs.

# Considerations

1. In the future, the scope of this repo may again shift to training SNNs in other simulators
2. In such instances where `swarmsim` is not necessary, it may take up extra space, especially with its own dependencies
3. It doesn't help dev installs, and may make things take longer if step 5 happens before step 3 (`pip` or `uv pip` will first need to uninstall the `swarmsim` it got from PyPi and then install the editable one)