### PR TITLE
Account for type mismatch in new EONS in a backwards-compatible way

### DIFF
--- a/common/evolver.py
+++ b/common/evolver.py
@@ -1,6 +1,6 @@
 import os
 import time
-import datetime
+import numbers
 import numpy as np
 from multiprocessing import Pool
 from tqdm.contrib.concurrent import process_map
@@ -101,7 +101,7 @@ class Evolver:
 
         self.net_callback = lambda net: net
 
-    def initialize_population(self, moa_state=1):
+    def initialize_population(self, moa_state: int | list | None = 1):
         if self.do_print:
             t0 = time.time()
 
@@ -110,11 +110,23 @@ class Evolver:
         self.eo.set_template_network(template_net)
 
         # Generate a new initial population for this EONS instance
-        self.pop = self.eo.generate_population(self.eons_params, moa_state)
+        self.pop = self.generate_population(self.eons_params, moa_state)
 
         if self.do_print:
             print("Initialized population of {} networks in {:8.5f} seconds".format(
                 len(self.pop.networks), time.time() - t0))
+
+    def generate_population(self, eons_params, moa_state: int | list[int] | None = None):
+        if moa_state is None:
+            return self.eo.generate_population(eons_params)
+        try:
+            return self.eo.generate_population(self.eons_params, moa_state)
+        except TypeError:
+            try:
+                moa_state = [int(moa_state)]
+            except TypeError:
+                moa_state = [moa_state]
+            return self.eo.generate_population(eons_params, moa_state)
 
     def pre_epoch(self):
         f = getattr(self.app, 'pre_epoch', None)

--- a/common/evolver.py
+++ b/common/evolver.py
@@ -18,6 +18,9 @@ from dataclasses import dataclass
 from typing import Tuple, override
 
 
+DEFAULT_MOA_STATE = [1, 1, 1, 1, 1]
+
+
 @dataclass
 class EpochInfo:
     """Class for the results of an epoch"""
@@ -101,7 +104,7 @@ class Evolver:
 
         self.net_callback = lambda net: net
 
-    def initialize_population(self, moa_state: int | list | None = 1):
+    def initialize_population(self, moa_state: list[int] | None = DEFAULT_MOA_STATE):
         if self.do_print:
             t0 = time.time()
 
@@ -116,17 +119,16 @@ class Evolver:
             print("Initialized population of {} networks in {:8.5f} seconds".format(
                 len(self.pop.networks), time.time() - t0))
 
-    def generate_population(self, eons_params, moa_state: int | list[int] | None = None):
+    def generate_population(self, eons_params, moa_state: list[int] | None = None):
         if moa_state is None:
             return self.eo.generate_population(eons_params)
-        try:
-            return self.eo.generate_population(self.eons_params, moa_state)
-        except TypeError:
+        elif moa_state == DEFAULT_MOA_STATE:
             try:
-                moa_state = [int(moa_state)]
+                return self.eo.generate_population(eons_params, moa_state)
             except TypeError:
-                moa_state = [moa_state]
-            return self.eo.generate_population(eons_params, moa_state)
+                return self.eo.generate_population(eons_params, 1)
+        else:
+            return self.eo.generate_population(self.eons_params, moa_state)
 
     def pre_epoch(self):
         f = getattr(self.app, 'pre_epoch', None)


### PR DESCRIPTION
This change *should* require no changes to your training code. It addresses a `TypeError` when `train`ing, caused by EONS no longer accepting an `int` for the `moa_state` parameter in `EONS.generate_population(eons_params, moa_state)`. This was changed in https://bitbucket.org/neuromorphic-utk/eons/commits/ed3dbff2359604fc0f11c8f60710c71440f93c83.

It is backwards compatible for users who have never touched `moa_state`. This parameter previously accepted a single int without error (although who knows if this actually behaved correctly; the commit linked above says it was broken). If the default value is passed, then we first try to pass a list of 5 ints. If this throws `TypeError`, we pass a single int `1` instead, which was the old default.

Users who previously passed a value to `moa_state` now need to pass a proper list of 5 ints.

Also, fun fact, something about the milling training procedure is not deterministic for some reason! I run the training with `--eons_seed 20` and it gives me a different result each time. This was verified for the following framework states:

| | Header | Header |
|--------|--------|--------|
| `framework` | `d4760b9ff485eced57cdcd8b69b3b39b328309d7` (Jul 08, 2024) | `32b1e975992283cd937b23ae3fc641c7881f7611` (Jul 08, 2025) |
| `framework/eons` | `abe8b5222a2e26a43147a7ac0f0bbf718f512426` (Apr 12, 2024) | `d531070a53796b1f2fd9276b0b0afa7d90d70c62` (Jul 02, 2025) |
| `framework/processors/caspian` | `ea9cc0cc802a989fec53c9a6bfe9b306c71e73c1` (May 14, 2024) | `75a7a63eb730fc8b13c5445d12dfd58f762e47af` (May 28, 2025) |


It should be noted that some time around/before/after Mar. 07th, 2024 `0fb4f6bb515bf2f2c0320149e02f3c789e016076` on `framework`, we did actually have fully deterministic training, i.e. run it multiple times with the same seeds, and it would do the exact same thing. I feel like this was true even in Jan 2025, but I don't know for sure.