### PR TITLE
fix --all_counts_stream crashing due to CaspianBinaryController refactor

### DIFF
--- a/experiment_tenn2.py
+++ b/experiment_tenn2.py
@@ -97,8 +97,8 @@ class ConnorMillingExperiment(TennExperiment):
             a = world.selected
             if a and self.iostream:
                 self.iostream.write_json({
-                    "Neuron Alias": a.neuron_ids,
-                    "Event Counts": a.neuron_counts
+                    "Neuron Alias": a.controller.neuron_ids,
+                    "Event Counts": a.controller.neuron_counts
                 })
 
         gui = TennlabGUI(x=0, y=0, h=0, w=300)


### PR DESCRIPTION
`--all_counts_stream` worked by checking the `selected_agent.neuron_ids` and `selected_agent.neuron_counts`. After moving the SNN stuff and these properties off the agent  to `CaspianBinaryController`, `--all_counts_stream`'s callback in `experiment_tenn2.py`>`ConnorMillingExperiment.simulate.callback()` broke as it could no longer access those attributes on the agent.

This change redirects it to the controller on that agent, assuming it's a `CaspianBinaryController` or a subclass of that.

This was tested as working on `CasPyanBinaryController` and `CasPyanBinaryRemappedController` too, albeit on a system with caspian/framework installed.