### PR TITLE
try using number of agents from project artifacts

### DIFF
--- a/common/experiment.py
+++ b/common/experiment.py
@@ -63,7 +63,7 @@ class TennExperiment(Application):
             self.save_strategy = "one_best"
 
         # set project mode.
-        self.p: project.Project | project.FolderlessProject
+        self.p: project.UnzippedProject | project.FolderlessProject
         if args.project is None and args.network:
             # don't create a project folder. Some features will be unavailable.
             self.p = project.FolderlessProject(args.network, args.logfile)


### PR DESCRIPTION
If the action is **_not_** `train` (i.e. you're running either `python experiment_tenn2.py run` or `test`), try loading the number of agents in the project file, which should be the number of agents that the network was trained with.

It will fall back to the `world.yaml` file that everything else is loaded from otherwise.